### PR TITLE
docs: 修复失效的 Star 历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@
 
 
 ## Star 历史
-<a href="https://www.star-history.com/?repos=XingHeYuZhuan%2Fshiguangschedule&type=timeline&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=XingHeYuZhuan/shiguangschedule&type=timeline&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=XingHeYuZhuan/shiguangschedule&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=XingHeYuZhuan/shiguangschedule&type=timeline&legend=top-left" />
- </picture>
+<a href="https://star-history.dera.page/#XingHeYuZhuan/shiguangschedule&type=timeline&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=XingHeYuZhuan/shiguangschedule&type=timeline&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=XingHeYuZhuan/shiguangschedule&type=timeline&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=XingHeYuZhuan/shiguangschedule&type=timeline&legend=top-left" />
+  </picture>
 </a>


### PR DESCRIPTION
当前 README 中的 Star 历史图表因 star-history.com 受 GitHub stargazer API 限制而无法正常显示，需要尽快修复。本 PR 将图表迁移至 star-history.dera.page 并改用 /svg 接口，恢复图表的正常展示。